### PR TITLE
Fix paste dangerousHTML, add .preventNL, add build script command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ The directive uses innerText to manipulate the DOM by default. However, you can 
 v-contenteditable:someDataKey.dangerousHTML="true"
 ```
 Be sure to protect your app against XSS!
+
+
+You can also disable newlines by adding the ``.preventNL`` modifier. Then, if the user press Enter, nothing will happen. Also, paste events are filtered to replace all newlines with a space.
+```
+v-contenteditable:someDataKey.preventNL="true"
+```
+

--- a/dist/index.js
+++ b/dist/index.js
@@ -6,6 +6,10 @@
 
   var index = {
     install: function install(Vue) {
+      function replaceAll(str, search, replacement) {
+        return str.split(search).join(replacement);
+      }    
+      
       Vue.directive("contenteditable", {
         bind: function bind(el, _ref, vnode) {
           var arg = _ref.arg,
@@ -27,6 +31,26 @@
           el.onblur = function (event) {
             el[innerValue] = el.dataset[key];
           };
+          if (!modifiers.dangerousHTML) {
+            el.addEventListener('paste', function (ev) {
+              ev.preventDefault();
+              var text = (ev.originalEvent || ev).clipboardData.getData('text/plain');
+              if (modifiers.preventNL) {
+                text = replaceAll(text, '\r\n', ' ');
+                text = replaceAll(text, '\n', ' ');
+                text = replaceAll(text, '\r', ' ');
+              }
+              window.document.execCommand('insertText', false, text);
+            });
+          }
+          if (modifiers.preventNL) {
+            el.addEventListener('keypress', function (ev) {
+              if (ev.key == 'Enter') {
+                ev.preventDefault();
+              }
+            });
+          }
+
           el.dataset[key] = vnode.context[key];
           el[innerValue] = vnode.context[key];
           return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-contenteditable-directive",
-  "version": "1.1.3",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "vue-contenteditable-directive",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "v-model isn't compatible with contentdeditable divs - this directive fills in",
   "main": "dist/index.js",
   "scripts": {
+    "build": "rollup -c",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
 export default {
   install(Vue) {
+    
+    function replaceAll(str, search, replacement) {
+      return str.split(search).join(replacement);
+    };
     Vue.directive("contenteditable", {
       bind(el, { arg, value, expression, modifiers }, vnode) {
         const innerValue = modifiers.dangerousHTML ? "innerHTML" : "innerText";
@@ -16,6 +20,26 @@ export default {
         el.onblur = function(event) {
           el[innerValue] = el.dataset[key];
         };
+        if(!modifiers.dangerousHTML){
+          el.addEventListener('paste', function (ev) {
+            ev.preventDefault();
+            let text = (ev.originalEvent || ev).clipboardData.getData('text/plain');
+            if(modifiers.preventNL) {
+              text = replaceAll(text, '\r\n', ' ')
+              text = replaceAll(text, '\n', ' ')
+              text = replaceAll(text, '\r', ' ')
+            }
+            window.document.execCommand('insertText', false, text);
+          });
+        }
+        if(modifiers.preventNL) {
+          el.addEventListener('keypress', function (ev) {
+            if(ev.key == 'Enter') {
+              ev.preventDefault();
+            }
+          });
+        }
+        
         el.dataset[key] = vnode.context[key];
         el[innerValue] = vnode.context[key];
         return;


### PR DESCRIPTION
1) Added the command build (rollup -c)

2) Added a paste event to to remove html when dangerousHTML is disable to avoid XSS by hijacking the clipboard

3) Added a preventNL modifier that permits to forbid to enter any newline in the content editable.

3bis) added documentation in the README for .preventNL